### PR TITLE
补全server.servlet.encoding.charsets的默认值和说明

### DIFF
--- a/11.Server.md
+++ b/11.Server.md
@@ -37,7 +37,7 @@
 | `server.servlet.application-display-name` | `application` | 显示应用程序的名称。 |
 | `server.servlet.context-parameters.*` |  | Servlet上下文初始化参数。|
 | `server.servlet.context-path` |  | 应用程序的上下文路径。|
-| `erver.servlet.encoding.charsets` |  |  |
+| `server.servlet.encoding.charsets` |  |  |
 | `server.servlet.encoding.enabled` | `true` | 是否启用http编码支持。 |
 | `server.servlet.encoding.force` |  |  |
 | `server.servlet.encoding.force-request` |  | |

--- a/11.Server.md
+++ b/11.Server.md
@@ -37,7 +37,7 @@
 | `server.servlet.application-display-name` | `application` | 显示应用程序的名称。 |
 | `server.servlet.context-parameters.*` |  | Servlet上下文初始化参数。|
 | `server.servlet.context-path` |  | 应用程序的上下文路径。|
-| `server.servlet.encoding.charsets` |  |  |
+| `server.servlet.encoding.charsets` | `UTF-8`| HTTP 请求和响应的字符集。 如果未明确设置，则添加到“Content-Type”标头。 |
 | `server.servlet.encoding.enabled` | `true` | 是否启用http编码支持。 |
 | `server.servlet.encoding.force` |  |  |
 | `server.servlet.encoding.force-request` |  | |


### PR DESCRIPTION
默认值和说明来源于源码

文件: org.springframework.boot.web.servlet.server.Encoding

```java
	/**
	 * Default HTTP encoding for Servlet applications.
	 */
	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;

	/**
	 * Charset of HTTP requests and responses. Added to the "Content-Type" header if not
	 * set explicitly.
	 */
	private Charset charset = DEFAULT_CHARSET;
```